### PR TITLE
Allow custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,21 @@ Sample configuration looks like this:
 }
 ```
 
-### Bundled templates
+### Templates
 
-There are following templates bundled:
+The following templates are bundled with Swaggie:
 
 ```
 axios     Default template. Recommended for React / Vue / similar frameworks. Uses axios
 fetch     Template similar to axios, but uses fetch instead. Recommended for React / Vue / similar frameworks
 ng1       Template for Angular 1 (this is for the old one)
 ng2       Template for Angular 2+ (uses HttpClient, InjectionTokens, etc)
+```
+
+If you want to use your own template, you can use the path to your template for the `-t` parameter:
+
+```
+swaggie -s https://petstore.swagger.io/v2/swagger.json -o ./client/petstore --template ./my-swaggie-template/
 ```
 
 ### Code

--- a/src/gen/templateManager.spec.ts
+++ b/src/gen/templateManager.spec.ts
@@ -50,7 +50,8 @@ describe('loadAllTemplateFiles', () => {
     expect(ejs.cache).toBeDefined();
     expect(ejs.cache.get(GOOD_FILE)).toBeInstanceOf(Function);
 
-    fs.rmdirSync(tempDir, { recursive: true });
+    fs.unlinkSync(path.join(tempDir, 'client.ejs'));
+    fs.rmdirSync(tempDir);
   })
 
   it('actually clears EJS cache', async () => {

--- a/src/gen/templateManager.spec.ts
+++ b/src/gen/templateManager.spec.ts
@@ -1,3 +1,6 @@
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
 import * as ejs from 'ejs';
 import { loadAllTemplateFiles, renderFile } from './templateManager';
 
@@ -29,6 +32,26 @@ describe('loadAllTemplateFiles', () => {
       loadAllTemplateFiles(null);
     }).toThrowError('No template');
   });
+
+  it('should handle custom template', async () => {
+    const tempDir = `${os.tmpdir()}/custom-template`;
+
+    if (!fs.existsSync(tempDir)){
+      fs.mkdirSync(tempDir);
+    }
+
+    fs.copyFileSync(
+      path.join(__dirname, '..', '..', 'templates', 'fetch', 'client.ejs'),
+      path.join(tempDir, 'client.ejs')
+    );
+
+    loadAllTemplateFiles(tempDir)
+
+    expect(ejs.cache).toBeDefined();
+    expect(ejs.cache.get(GOOD_FILE)).toBeInstanceOf(Function);
+
+    fs.rmdirSync(tempDir, { recursive: true });
+  })
 
   it('actually clears EJS cache', async () => {
     loadAllTemplateFiles('axios');

--- a/src/gen/templateManager.ts
+++ b/src/gen/templateManager.ts
@@ -7,7 +7,9 @@ export function loadAllTemplateFiles(templateName: string) {
   if (!templateName) {
     throw new Error(`No template name was provided`);
   }
-  const templatesDir = path.join(__dirname, '..', '..', 'templates', templateName);
+  const templatesDir = fs.existsSync(templateName)
+    ? templateName
+    : path.join(__dirname, '..', '..', 'templates', templateName);
   if (!fs.existsSync(templatesDir)) {
     throw new Error(
       `Could not found directory with the template (we tried ${templatesDir}). Template name is correct?`


### PR DESCRIPTION
hey! happy hacktoberfest 🎃!

This is a change that allows for custom templates to be used.

```
swaggie -s swagger.json -o ./client/petstore/ --template ./custom-template/
```

This is useful for extending the templates that ship with Swaggie, or for implementing a new template for a different HTTP client.