### PR TITLE
fix: exclude blob types from adding toString

### DIFF
--- a/templates/axios/operation.ejs
+++ b/templates/axios/operation.ejs
@@ -21,7 +21,7 @@
     <%_ if(parameter.original && parameter.original.type === 'array') { -%>
       <%- parameter.name -%>.forEach((f: any) => formDataBody.append("<%- parameter.originalName -%>", f));
     <%_ } else { %>
-      formDataBody.append("<%- parameter.originalName -%>", <%- parameter.name -%><%- parameter.type !== 'string' ? '.toString()' : '' -%>);
+      formDataBody.append("<%- parameter.originalName -%>", <%- parameter.name -%><%- parameter.type !== 'string' && parameter.type !== 'File' && parameter.type !== 'Blob' ? '.toString()' : '' -%>);
     <%_ } %>
     }
 <% });


### PR DESCRIPTION
After a recent [fix](https://github.com/yhnavein/swaggie/commit/ad6fde878a8f85e22f1d5d2f138df0327e858540) the support for files was broken, which adds `toString()` to each param of type `File` or `Blob`.